### PR TITLE
feat: Add direct HTTP(S) .py URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Direct installation and update support for raw HTTP(S) Python `.py` source URLs
+
 ## [1.6.0] - 2026-02-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/lalvarezt/uv-script-manager/workflows/CI/badge.svg)](https://github.com/lalvarezt/uv-script-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A CLI tool to install and manage standalone Python scripts from Git repositories or local directories that lack
+A CLI tool to install and manage standalone Python scripts from direct URLs, Git repositories, or local directories that lack
 `setup.py` or `pyproject.toml` files.
 
 ## Overview
@@ -40,6 +40,7 @@ script.py --help
 
 - **Direct Git Installation**: Install scripts from any Git repository (GitHub, GitLab, Bitbucket, self-hosted) with one
 command
+- **Direct URL Installation**: Install and update raw HTTP(S) `.py` source files, including raw GitHub Gist links
 - **Local Directory Support**: Install scripts from local directories on your filesystem
 - **Script Aliasing**: Install scripts with custom names using the `--alias` flag
 - **Git Refs Support**: Install from specific branches, tags, or commits (pinned refs are preserved during updates)
@@ -89,6 +90,9 @@ uv pip install -e .
 # Basic installation
 uv-script-manager install https://github.com/user/repo --script script.py
 
+# Install a direct Python source URL
+uv-script-manager install https://example.com/tool.py
+
 # Install from a local directory (no git required)
 uv-script-manager install ./tools --script app.py
 
@@ -112,7 +116,7 @@ uv-script-manager remove script.py
 
 ### `install`
 
-Install Python scripts from a Git repository or local directory.
+Install Python scripts from a direct URL, Git repository, or local directory.
 
 ```bash
 uv-script-manager install <source> [--script <script.py> ...] [OPTIONS]
@@ -120,10 +124,13 @@ uv-script-manager install <source> [--script <script.py> ...] [OPTIONS]
 
 **Arguments:**
 
-- `source`: Git repository URL or local directory path (Git URLs support `@tag`, `@commit`, `#branch` suffixes)
+- `source`: Direct HTTP(S) `.py` URL, Git repository URL, or local directory path
 
 If `--script` is omitted in an interactive terminal, the CLI prompts you to select scripts from discovered
-candidates. In non-interactive environments, `--script` is required.
+candidates. Direct `.py` URLs identify one script and do not use `--script`.
+
+Direct URL downloads have a 10 MiB limit and retain the original URL for updates. HTML pages, compiled Python
+files (`.pyc`, `.pyo`), native extensions, zipapps, wheels, and other non-`.py` files are not supported.
 
 **Options:**
 
@@ -145,6 +152,10 @@ sources this requires `--copy-parent-dir`)
 ```bash
 # Basic installation from Git
 uv-script-manager install https://github.com/user/repo --script script.py
+
+# Install a raw Python source file or raw Gist
+uv-script-manager install https://example.com/tool.py
+uv-script-manager install https://gist.githubusercontent.com/user/id/raw/tool.py
 
 # Install from local directory
 uv-script-manager install /path/to/scripts --script app.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
   "pytest-cov>=7.0.0",
   "pytest-mock>=3.15.1",
   "ruff>=0.14.2",
-  "ty>=0.0.1a25",
+  "ty>=0.0.49",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/uv_script_manager/cli.py
+++ b/src/uv_script_manager/cli.py
@@ -292,7 +292,7 @@ def _filter_and_sort_scripts(
             if source_text
             in (
                 (script.source_url or "")
-                if script.source_type == SourceType.GIT
+                if script.source_type in (SourceType.GIT, SourceType.URL)
                 else str(script.source_path or "")
             ).lower()
         ]
@@ -307,8 +307,8 @@ def _filter_and_sort_scripts(
 
     if status_filter:
         status_key = status_filter.lower()
-        if status_key == "git":
-            filtered = [script for script in filtered if script.source_type == SourceType.GIT]
+        if status_key in ("git", "url"):
+            filtered = [script for script in filtered if script.source_type.value == status_key]
         else:
             filtered = [
                 script
@@ -323,7 +323,7 @@ def _filter_and_sort_scripts(
             filtered,
             key=lambda script: (
                 (script.source_url or "")
-                if script.source_type == SourceType.GIT
+                if script.source_type in (SourceType.GIT, SourceType.URL)
                 else str(script.source_path or "")
             ).lower(),
         )
@@ -352,11 +352,12 @@ def _script_to_json(
         "display_name": script.display_name,
         "source_type": script.source_type.value,
         "source": script.source_url
-        if script.source_type == SourceType.GIT
+        if script.source_type in (SourceType.GIT, SourceType.URL)
         else str(script.source_path or ""),
         "ref": script.ref,
         "ref_type": script.ref_type,
         "commit_hash": script.commit_hash,
+        "source_hash": script.source_hash,
         "installed_at": script.installed_at.isoformat(),
         "dependencies": script.dependencies,
         "repo_path": str(script.repo_path),
@@ -424,11 +425,12 @@ def _print_update_all_impact_summary(state_manager: StateManager, dry_run: bool)
         return
 
     local_count = sum(1 for script in scripts if script.source_type.value == "local")
-    git_count = len(scripts) - local_count
+    git_count = sum(1 for script in scripts if script.source_type.value == "git")
+    url_count = sum(1 for script in scripts if script.source_type.value == "url")
     pinned_count = sum(1 for script in scripts if script.ref_type in ("tag", "commit"))
 
     console.print("[bold]Impact:[/bold] update --all")
-    console.print(f"  Scripts: {len(scripts)} ({git_count} git, {local_count} local-only)")
+    console.print(f"  Scripts: {len(scripts)} ({git_count} git, {url_count} url, {local_count} local-only)")
     if pinned_count:
         console.print(
             "  Pinned refs: "
@@ -480,7 +482,7 @@ def _print_needs_attention_hint(scripts) -> None:
 )
 @click.pass_context
 def cli(ctx: click.Context, config: Path | None) -> None:
-    """Install and manage Python scripts from Git repositories or local directories."""
+    """Install and manage Python scripts from URLs, Git repositories, or local directories."""
     ctx.ensure_object(dict)
 
     # Load configuration
@@ -499,12 +501,12 @@ def cli(ctx: click.Context, config: Path | None) -> None:
 
 
 @cli.command()
-@click.argument("git-url")
+@click.argument("source")
 @click.option(
     "--script",
     "-s",
     multiple=True,
-    help="Script names to install (can be specified multiple times)",
+    help="For Git/local sources: script names to install (can be specified multiple times)",
 )
 @click.option(
     "--with",
@@ -533,7 +535,7 @@ def cli(ctx: click.Context, config: Path | None) -> None:
 @click.option(
     "--add-source-package",
     default=None,
-    help="Add source as a local package dependency (optional: specify package name)",
+    help="For Git/local sources: add source as a local package dependency (optional: specify package name)",
 )
 @click.option(
     "--alias",
@@ -548,7 +550,7 @@ def cli(ctx: click.Context, config: Path | None) -> None:
 @click.pass_context
 def install(
     ctx: click.Context,
-    git_url: str,
+    source: str,
     script: tuple[str, ...],
     with_deps: str | None,
     force: bool,
@@ -562,7 +564,7 @@ def install(
     no_deps: bool,
 ) -> None:
     """
-    Install Python scripts from a Git repository or local directory.
+    Install Python scripts from a direct URL, Git repository, or local directory.
 
     Downloads the specified repository (or copies from local directory),
     processes the requested scripts, adds dependencies, modifies shebangs
@@ -573,6 +575,10 @@ def install(
         \b
         # Install from Git repository
         uv-script-manager install https://github.com/user/repo --script myscript.py
+
+        \b
+        # Install from a direct Python source URL
+        uv-script-manager install https://example.com/myscript.py
 
         \b
         # Install from local directory
@@ -614,14 +620,19 @@ def install(
         uv-script-manager install https://github.com/user/repo --script app.py --no-deps
     """
     config = ctx.obj["config"]
+    from .url_source import UNSUPPORTED_URL_SOURCE, is_python_source_url, is_unsupported_python_file_url
 
     selected_scripts = script
+    is_url_source = is_python_source_url(source)
+    if is_unsupported_python_file_url(source):
+        console.print(f"[red]Error:[/red] {UNSUPPORTED_URL_SOURCE}")
+        sys.exit(1)
 
-    if not selected_scripts:
+    if not selected_scripts and not is_url_source:
         from .utils import is_git_url, is_local_directory
 
-        if not (is_local_directory(git_url) or is_git_url(git_url)):
-            console.print(f"[red]Error:[/red] Invalid source: {git_url}")
+        if not (is_local_directory(source) or is_git_url(source)):
+            console.print(f"[red]Error:[/red] Invalid source: {source}")
             console.print("Source must be either a Git URL or a local directory path.")
             sys.exit(1)
 
@@ -634,7 +645,7 @@ def install(
             sys.exit(1)
 
         try:
-            candidates = _discover_install_script_candidates(git_url, config.clone_depth)
+            candidates = _discover_install_script_candidates(source, config.clone_depth)
         except ValueError as e:
             console.print(f"[red]Error:[/red] Failed to discover scripts: {e}")
             sys.exit(1)
@@ -649,7 +660,7 @@ def install(
         selected_scripts = _prompt_for_script_selection(candidates)
 
     # Validate --alias flag usage
-    if alias is not None and len(selected_scripts) != 1:
+    if alias is not None and not is_url_source and len(selected_scripts) != 1:
         console.print("[red]Error:[/red] --alias can only be used when installing a single script")
         sys.exit(1)
 
@@ -668,7 +679,7 @@ def install(
             alias=alias,
             no_deps=no_deps,
         )
-        results = handler.install(source=git_url, scripts=selected_scripts, request=request)
+        results = handler.install(source=source, scripts=selected_scripts, request=request)
 
         install_directory = install_dir if install_dir else config.install_dir
         display_install_results(results, install_directory, console)
@@ -1147,6 +1158,8 @@ def export_scripts(ctx: click.Context, output: Path | None) -> None:
             if script.ref_type:
                 script_data["ref_type"] = script.ref_type
             script_data["source"] = source_url
+        elif script.source_type == SourceType.URL:
+            script_data["source"] = script.source_url
         else:
             script_data["source"] = str(script.source_path) if script.source_path else None
             script_data["copy_parent_dir"] = script.copy_parent_dir
@@ -1269,7 +1282,8 @@ def import_scripts(ctx: click.Context, file: Path, force: bool, dry_run: bool) -
                 alias=alias,
                 no_deps=False,
             )
-            result = handler.install(source=source, scripts=(name,), request=request)
+            install_scripts = () if source_type == SourceType.URL.value else (name,)
+            result = handler.install(source=source, scripts=install_scripts, request=request)
             results.extend(result)
         except (ValueError, FileNotFoundError, NotADirectoryError) as e:
             results.append((name, False, str(e)))

--- a/src/uv_script_manager/cli.py
+++ b/src/uv_script_manager/cli.py
@@ -5,7 +5,6 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import cast
 
 # Runtime version check - must be before other imports
 if sys.version_info < (3, 11):
@@ -376,9 +375,9 @@ def _update_results_to_json(results: list[tuple[str, str] | tuple[str, str, str]
     payload: list[dict[str, object]] = []
     for result in results:
         if len(result) == 3:
-            script_name, status, local_changes = cast(tuple[str, str, str], result)
+            script_name, status, local_changes = result
         else:
-            script_name, status = cast(tuple[str, str], result)
+            script_name, status = result
             local_changes = None
         payload.append(
             {

--- a/src/uv_script_manager/commands/install.py
+++ b/src/uv_script_manager/commands/install.py
@@ -1,5 +1,6 @@
 """Install command handler."""
 
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -25,6 +26,14 @@ from ..script_installer import (
     install_script,
 )
 from ..state import ScriptInfo, StateManager
+from ..url_source import (
+    UNSUPPORTED_URL_SOURCE,
+    URLSourceError,
+    download_url_script,
+    is_python_source_url,
+    is_unsupported_python_file_url,
+    managed_url_directory,
+)
 from ..utils import (
     copy_directory_contents,
     copy_script_file,
@@ -55,6 +64,9 @@ class InstallationContext:
     commit_hash: str | None
     actual_ref: str | None
     git_ref: GitRef | None
+    is_url: bool = False
+    source_url: str | None = None
+    source_hash: str | None = None
 
 
 @dataclass
@@ -113,7 +125,7 @@ class InstallHandler:
         request: InstallRequest,
     ) -> list[tuple[str, bool, Path | None | str]]:
         """
-        Install Python scripts from a Git repository or local directory.
+        Install Python scripts from a Git repository, local directory, or direct URL.
 
         Args:
             source: Git URL or local directory path
@@ -125,12 +137,30 @@ class InstallHandler:
         """
         # Detect and validate source type
         is_local = is_local_directory(source)
-        is_git = is_git_url(source)
+        is_url = is_python_source_url(source)
+        if is_unsupported_python_file_url(source):
+            self.console.print(f"[red]Error:[/red] {UNSUPPORTED_URL_SOURCE}")
+            raise ValueError(UNSUPPORTED_URL_SOURCE)
+        is_git = not is_url and is_git_url(source)
 
-        if not is_local and not is_git:
+        if not is_local and not is_git and not is_url:
             self.console.print(f"[red]Error:[/red] Invalid source: {source}")
-            self.console.print("Source must be either a Git URL or a local directory path.")
+            self.console.print("Source must be a Git URL, local directory path, or direct .py URL.")
             raise ValueError(f"Invalid source: {source}")
+
+        if is_url:
+            if scripts:
+                message = "--script cannot be used with a direct .py URL"
+                self.console.print(f"[red]Error:[/red] {message}")
+                raise ValueError(message)
+            if request.copy_parent_dir:
+                message = "--copy-parent-dir cannot be used with a direct .py URL"
+                self.console.print(f"[red]Error:[/red] {message}")
+                raise ValueError(message)
+            if request.add_source_package is not None:
+                message = "--add-source-package cannot be used with a direct .py URL"
+                self.console.print(f"[red]Error:[/red] {message}")
+                raise ValueError(message)
 
         # Validate --add-source-package requirements
         if request.add_source_package is not None and is_local and not request.copy_parent_dir:
@@ -138,14 +168,32 @@ class InstallHandler:
             self.console.print(error_msg)
             raise ValueError("--add-source-package requires --copy-parent-dir for local sources")
 
-        # Check for existing installations
-        if not self._check_existing_scripts(scripts, request.force):
-            return []
-
         # Handle source-specific operations
-        if is_git:
+        backup_path = None
+        source_hash = None
+        downloaded_url_script = None
+        if is_url:
+            try:
+                repo_path = managed_url_directory(self.config.repo_dir, source)
+                downloaded = download_url_script(source, repo_path)
+            except URLSourceError as e:
+                self.console.print(f"[red]Error:[/red] {e}")
+                raise ValueError(str(e)) from e
+            scripts = (downloaded.filename,)
+            if not self._check_existing_scripts(scripts, request.force):
+                downloaded.path.unlink(missing_ok=True)
+                return []
+            downloaded_url_script = downloaded
+            source_path = None
+            commit_hash = actual_ref = git_ref = None
+            source_hash = downloaded.source_hash
+        elif is_git:
+            if not self._check_existing_scripts(scripts, request.force):
+                return []
             repo_path, source_path, commit_hash, actual_ref, git_ref = self._handle_git_source(source)
         else:
+            if not self._check_existing_scripts(scripts, request.force):
+                return []
             repo_path, source_path, commit_hash, actual_ref, git_ref = self._handle_local_source(
                 source, scripts, request.copy_parent_dir
             )
@@ -156,13 +204,33 @@ class InstallHandler:
             if request.verbose:
                 self.console.print("[cyan]Skipping dependency resolution (--no-deps)[/cyan]")
         else:
-            dependencies = self._resolve_dependencies(
-                request.with_deps, repo_path, source_path, request.verbose
-            )
+            try:
+                dependencies = self._resolve_dependencies(
+                    request.with_deps, repo_path, source_path, request.verbose
+                )
+            except Exception:
+                if downloaded_url_script:
+                    downloaded_url_script.path.unlink(missing_ok=True)
+                raise
 
         # Determine installation directory
         install_directory = request.install_dir or self.config.install_dir
         ensure_dir(install_directory)
+
+        if downloaded_url_script:
+            target_path = repo_path / downloaded_url_script.filename
+            try:
+                if target_path.exists():
+                    backup_path = repo_path / f".{downloaded_url_script.filename}.uvsm-backup"
+                    os.replace(target_path, backup_path)
+                os.replace(downloaded_url_script.path, target_path)
+            except OSError as e:
+                downloaded_url_script.path.unlink(missing_ok=True)
+                if backup_path and backup_path.exists():
+                    os.replace(backup_path, target_path)
+                message = f"Failed to store URL source: {e}"
+                self.console.print(f"[red]Error:[/red] {message}")
+                raise ValueError(message) from e
 
         # Create installation context and options
         context = InstallationContext(
@@ -170,10 +238,13 @@ class InstallHandler:
             source_path=source_path,
             is_local=is_local,
             is_git=is_git,
+            is_url=is_url,
             copy_parent_dir=request.copy_parent_dir,
             commit_hash=commit_hash,
             actual_ref=actual_ref,
             git_ref=git_ref,
+            source_url=source if is_url else None,
+            source_hash=source_hash,
         )
         options = ScriptInstallOptions(
             dependencies=dependencies,
@@ -185,7 +256,17 @@ class InstallHandler:
         )
 
         # Install scripts
-        return [self._install_single_script(script_name, context, options) for script_name in scripts]
+        results = [self._install_single_script(script_name, context, options) for script_name in scripts]
+        if is_url:
+            target_path = context.repo_path / scripts[0]
+            if results[0][1]:
+                if backup_path:
+                    backup_path.unlink(missing_ok=True)
+            else:
+                target_path.unlink(missing_ok=True)
+                if backup_path:
+                    os.replace(backup_path, target_path)
+        return results
 
     def _check_existing_scripts(self, scripts: tuple[str, ...], force: bool) -> bool:
         """
@@ -443,6 +524,17 @@ class InstallHandler:
                     symlink_path=symlink_path,
                     dependencies=all_deps,
                     commit_hash=context.commit_hash,
+                )
+            elif context.is_url:
+                script_info = ScriptInfo(
+                    name=script_name,
+                    source_type=SourceType.URL,
+                    source_url=context.source_url,
+                    source_hash=context.source_hash,
+                    installed_at=datetime.now(),
+                    repo_path=context.repo_path,
+                    symlink_path=symlink_path,
+                    dependencies=all_deps,
                 )
             else:
                 script_info = ScriptInfo(

--- a/src/uv_script_manager/commands/update.py
+++ b/src/uv_script_manager/commands/update.py
@@ -129,7 +129,7 @@ class UpdateHandler:
             else:
                 self.console.print(f"Updating {len(scripts)} script(s)...")
 
-        results = []
+        results: list[tuple[str, str] | tuple[str, str, str]] = []
         git_checked = False
 
         for script_info in scripts:

--- a/src/uv_script_manager/commands/update.py
+++ b/src/uv_script_manager/commands/update.py
@@ -1,5 +1,6 @@
 """Update command handlers."""
 
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -29,6 +30,7 @@ from ..update_status import (
     make_error_status,
     make_pinned_status,
 )
+from ..url_source import URLSourceError, download_url_script
 from ..utils import copy_directory_contents, copy_script_file, handle_git_error, progress_spinner
 
 
@@ -79,6 +81,8 @@ class UpdateHandler:
         if dry_run:
             if script_info.source_type == SourceType.LOCAL:
                 return self._local_skip_dry_run_result(display_name)
+            if script_info.source_type == SourceType.URL:
+                return self._build_url_dry_run_result(script_info, force, refresh_deps)
 
             handle_git_error(self.console, lambda: verify_git_available())
             return self._build_git_dry_run_result(script_info, force, refresh_deps)
@@ -86,6 +90,8 @@ class UpdateHandler:
         # Branch based on source type (use actual script name from state, not user input)
         if script_info.source_type == SourceType.LOCAL:
             return self._update_local_script(script_info, exact, refresh_deps)
+        if script_info.source_type == SourceType.URL:
+            return self._update_url_script(script_info, force, exact, refresh_deps)
         else:
             return self._update_git_script(script_info, force, exact, refresh_deps)
 
@@ -137,6 +143,24 @@ class UpdateHandler:
                     results.append(self._local_skip_result(display_name))
                 continue
 
+            if script_info.source_type == SourceType.URL:
+                try:
+                    if dry_run:
+                        results.append(self._build_url_dry_run_result(script_info, force, refresh_deps))
+                    else:
+                        results.append(
+                            (
+                                display_name,
+                                self._update_url_script_internal(script_info, force, exact, refresh_deps),
+                            )
+                        )
+                except (OSError, URLSourceError, ScriptInstallerError) as e:
+                    if dry_run:
+                        results.append((display_name, make_error_status(str(e)), "N/A"))
+                    else:
+                        results.append((display_name, make_error_status(str(e))))
+                continue
+
             # Verify git available once
             if not git_checked:
                 handle_git_error(self.console, lambda: verify_git_available())
@@ -155,6 +179,69 @@ class UpdateHandler:
                     results.append((display_name, make_error_status(str(e))))
 
         return results
+
+    def _update_url_script(
+        self,
+        script_info: ScriptInfo,
+        force: bool,
+        exact: bool | None,
+        refresh_deps: bool = False,
+    ) -> tuple[str, str]:
+        """Update a direct URL script."""
+        try:
+            status = self._update_url_script_internal(script_info, force, exact, refresh_deps)
+            return (script_info.display_name, status)
+        except (OSError, URLSourceError, ScriptInstallerError) as e:
+            return (script_info.display_name, make_error_status(str(e)))
+
+    def _update_url_script_internal(
+        self,
+        script_info: ScriptInfo,
+        force: bool,
+        exact: bool | None,
+        refresh_deps: bool = False,
+    ) -> str:
+        """Download, compare, and safely reinstall a direct URL script."""
+        if not script_info.source_url:
+            raise URLSourceError("URL source is missing its source URL")
+
+        downloaded = download_url_script(script_info.source_url, script_info.repo_path)
+        target_path = script_info.repo_path / script_info.name
+        backup_path = script_info.repo_path / f".{script_info.name}.uvsm-backup"
+
+        if downloaded.filename != script_info.name:
+            downloaded.path.unlink(missing_ok=True)
+            raise URLSourceError(f"URL filename changed from '{script_info.name}' to '{downloaded.filename}'")
+
+        if downloaded.source_hash == script_info.source_hash and not force and not refresh_deps:
+            downloaded.path.unlink(missing_ok=True)
+            return UPDATE_STATUS_UP_TO_DATE
+
+        dependencies = self._resolve_dependencies_for_update(
+            script_info.dependencies,
+            script_info.repo_path,
+            refresh_deps,
+        )
+        script_alias = self._get_script_alias(script_info, script_info.name)
+        old_source_hash = script_info.source_hash
+
+        try:
+            if target_path.exists():
+                os.replace(target_path, backup_path)
+            os.replace(downloaded.path, target_path)
+            symlink_path = self._reinstall_script(target_path, dependencies, exact, script_alias)
+            script_info.source_hash = downloaded.source_hash
+            self._persist_script_update(script_info, dependencies, symlink_path)
+        except Exception:
+            script_info.source_hash = old_source_hash
+            target_path.unlink(missing_ok=True)
+            if backup_path.exists():
+                os.replace(backup_path, target_path)
+            downloaded.path.unlink(missing_ok=True)
+            raise
+
+        backup_path.unlink(missing_ok=True)
+        return UPDATE_STATUS_UPDATED
 
     def _update_local_script(
         self, script_info: ScriptInfo, exact: bool | None, refresh_deps: bool = False
@@ -403,3 +490,27 @@ class UpdateHandler:
         )
         local_changes = format_local_change_label(local_change_state)
         return (script_info.display_name, status, local_changes)
+
+    def _build_url_dry_run_result(
+        self,
+        script_info: ScriptInfo,
+        force: bool,
+        refresh_deps: bool,
+    ) -> tuple[str, str, str]:
+        """Build dry-run update result for a direct URL script."""
+        if not script_info.source_url:
+            raise URLSourceError("URL source is missing its source URL")
+        downloaded = download_url_script(script_info.source_url, script_info.repo_path)
+        try:
+            if downloaded.filename != script_info.name:
+                raise URLSourceError(
+                    f"URL filename changed from '{script_info.name}' to '{downloaded.filename}'"
+                )
+            status = (
+                UPDATE_STATUS_WOULD_UPDATE
+                if force or refresh_deps or downloaded.source_hash != script_info.source_hash
+                else UPDATE_STATUS_UP_TO_DATE
+            )
+            return (script_info.display_name, status, "N/A")
+        finally:
+            downloaded.path.unlink(missing_ok=True)

--- a/src/uv_script_manager/constants.py
+++ b/src/uv_script_manager/constants.py
@@ -10,10 +10,12 @@ class SourceType(str, Enum):
     Attributes:
         GIT: Script installed from Git repository
         LOCAL: Script installed from local filesystem
+        URL: Script installed from a direct Python source URL
     """
 
     GIT = "git"
     LOCAL = "local"
+    URL = "url"
 
 
 # Script inline metadata markers (PEP 723)

--- a/src/uv_script_manager/display.py
+++ b/src/uv_script_manager/display.py
@@ -37,7 +37,7 @@ def _normalize_status_key(status_key: str) -> str:
         "no (managed)": "managed",
     }
     normalized = aliases.get(normalized, normalized)
-    known = {"clean", "pinned", "local", "needs-attention", "managed", "unknown", "git"}
+    known = {"clean", "pinned", "local", "needs-attention", "managed", "unknown", "git", "url"}
     return normalized if normalized in known else "unknown"
 
 
@@ -69,6 +69,8 @@ def get_script_status_key(script: ScriptInfo, local_changes_cache: dict[tuple[Pa
     """Derive canonical status key used in list/show/doctor displays."""
     if script.source_type == SourceType.LOCAL:
         return "local"
+    if script.source_type == SourceType.URL:
+        return "url"
 
     if script.ref_type in ("tag", "commit"):
         return "pinned"
@@ -104,6 +106,8 @@ def get_script_source_display(
             return script.source_url
         source_parts = script.source_url.rstrip("/").split("/")
         return "/".join(source_parts[-2:]) if len(source_parts) >= 2 else script.source_url
+    if script.source_type == SourceType.URL:
+        return script.source_url or "unknown"
     return str(script.source_path) if script.source_path else "local"
 
 
@@ -118,6 +122,7 @@ def render_script_status(status_key: str, detail: str | None = None) -> str:
         "managed": "[green]Managed[/green]",
         "unknown": "[dim]Unknown[/dim]",
         "git": "[cyan]Git[/cyan]",
+        "url": "[cyan]URL[/cyan]",
     }
     rendered = labels[status_key]
     if detail:
@@ -431,6 +436,10 @@ def display_script_details(script: ScriptInfo, console: Console) -> None:
             status_rows.append(("Reason:", change_reason))
         if local_state in ("blocking", "unknown") and script.repo_path.exists():
             status_rows.append(("Inspect with:", f"[cyan]git -C {script.repo_path} status --short[/cyan]"))
+    elif script.source_type == SourceType.URL:
+        table.add_row("Source type:", "Direct Python URL")
+        table.add_row("Source URL:", f"[magenta]{script.source_url or 'N/A'}[/magenta]")
+        table.add_row("Source hash:", f"[blue]{script.source_hash or 'N/A'}[/blue]")
     else:
         table.add_row("Source type:", "Local directory")
         source_path = str(script.source_path) if script.source_path else "N/A"

--- a/src/uv_script_manager/display.py
+++ b/src/uv_script_manager/display.py
@@ -2,7 +2,6 @@
 
 import os
 from pathlib import Path
-from typing import cast
 
 from rich.console import Console
 from rich.panel import Panel
@@ -352,18 +351,15 @@ def display_update_results(
     table.add_column("Script", style="cyan")
     table.add_column("Status")
 
-    show_local_changes = any(
-        len(result) == 3 and cast(tuple[str, str, str], result)[2].strip().lower() != "n/a"
-        for result in results
-    )
+    show_local_changes = any(len(result) == 3 and result[2].strip().lower() != "n/a" for result in results)
     if show_local_changes:
         table.add_column("Local changes")
 
     for result in results:
         if len(result) == 3:
-            script_name, status, local_changes = cast(tuple[str, str, str], result)
+            script_name, status, local_changes = result
         else:
-            script_name, status = cast(tuple[str, str], result)
+            script_name, status = result
             local_changes = "N/A"
 
         status_text = render_update_status(status)

--- a/src/uv_script_manager/state.py
+++ b/src/uv_script_manager/state.py
@@ -17,7 +17,7 @@ class ScriptInfo(BaseModel):
     Pydantic model that automatically handles serialization/deserialization,
     validation, and type coercion for script metadata.
 
-    Supports both Git and local sources via the source_type field.
+    Supports Git, local, and URL sources via the source_type field.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -33,6 +33,7 @@ class ScriptInfo(BaseModel):
     ref: str | None = None
     ref_type: str | None = None  # "branch", "tag", "commit", or "default"
     commit_hash: str | None = None
+    source_hash: str | None = None
     # Local-specific fields
     source_path: Path | None = None  # Original source path for updates
     copy_parent_dir: bool = False  # Whether entire parent directory was copied
@@ -45,7 +46,7 @@ class ScriptInfo(BaseModel):
     @property
     def source_display(self) -> str:
         """Get source display value for user-facing output."""
-        if self.source_type == SourceType.GIT:
+        if self.source_type in (SourceType.GIT, SourceType.URL):
             return self.source_url or "N/A"
         return str(self.source_path) if self.source_path else "local"
 
@@ -194,6 +195,8 @@ class StateManager:
                     issues.append(
                         f"Source directory missing for local script '{script.name}': {script.source_path}"
                     )
+            if script.source_type == SourceType.URL and not script.source_url:
+                issues.append(f"Source URL missing for URL script '{script.name}'")
 
         return issues
 

--- a/src/uv_script_manager/url_source.py
+++ b/src/uv_script_manager/url_source.py
@@ -1,0 +1,107 @@
+"""Direct Python source URL handling."""
+
+import hashlib
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urlparse
+from urllib.request import urlopen
+
+from pathvalidate import ValidationError, validate_filename
+
+from .utils import ensure_dir, validate_python_script
+
+URL_DOWNLOAD_TIMEOUT = 30
+URL_MAX_DOWNLOAD_SIZE = 10 * 1024 * 1024
+UNSUPPORTED_URL_SOURCE = "Unsupported URL source: uvsm only installs Python source files ending in .py"
+
+
+class URLSourceError(Exception):
+    """Raised when a direct Python source URL cannot be downloaded or validated."""
+
+
+@dataclass(frozen=True)
+class DownloadedURLScript:
+    """A validated URL download staged for atomic installation."""
+
+    path: Path
+    filename: str
+    source_hash: str
+
+
+def is_python_source_url(url: str) -> bool:
+    """Return whether URL is a direct HTTP(S) Python source URL."""
+    parsed = urlparse(url)
+    return parsed.scheme.lower() in ("http", "https") and unquote(parsed.path).lower().endswith(".py")
+
+
+def is_unsupported_python_file_url(url: str) -> bool:
+    """Return whether URL clearly targets an unsupported Python artifact."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in ("http", "https"):
+        return False
+    suffix = Path(unquote(parsed.path)).suffix.lower()
+    return suffix in {".pyc", ".pyo", ".pyz", ".so", ".pyd", ".dll", ".dylib", ".whl"}
+
+
+def managed_url_directory(repo_dir: Path, url: str) -> Path:
+    """Return deterministic managed directory for a source URL."""
+    url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
+    return repo_dir / f"url-{url_hash}"
+
+
+def download_url_script(url: str, destination_dir: Path) -> DownloadedURLScript:
+    """Download and validate a direct Python source URL into a temporary file."""
+    if not is_python_source_url(url):
+        raise URLSourceError(UNSUPPORTED_URL_SOURCE)
+
+    ensure_dir(destination_dir)
+    temp_path: Path | None = None
+    try:
+        with urlopen(url, timeout=URL_DOWNLOAD_TIMEOUT) as response:  # noqa: S310 - schemes validated
+            final_url = response.geturl()
+            final_parsed = urlparse(final_url)
+            if final_parsed.scheme.lower() not in ("http", "https"):
+                raise URLSourceError("URL redirect used an unsupported scheme")
+            if not is_python_source_url(final_url):
+                raise URLSourceError(UNSUPPORTED_URL_SOURCE)
+
+            filename = Path(unquote(final_parsed.path)).name
+            if not filename:
+                raise URLSourceError("URL does not contain a script filename")
+            try:
+                validate_filename(filename, platform="auto")
+            except ValidationError as e:
+                raise URLSourceError(f"Invalid script filename '{filename}': {e}") from e
+
+            content = response.read(URL_MAX_DOWNLOAD_SIZE + 1)
+            if len(content) > URL_MAX_DOWNLOAD_SIZE:
+                raise URLSourceError("URL source exceeds the 10 MiB download limit")
+
+        fd, temp_name = tempfile.mkstemp(prefix=".uvsm-url-", suffix=".py", dir=destination_dir)
+        temp_path = Path(temp_name)
+        with os.fdopen(fd, "wb") as temp_file:
+            temp_file.write(content)
+
+        if not validate_python_script(temp_path):
+            raise URLSourceError("Downloaded file is not a valid Python script")
+
+        return DownloadedURLScript(
+            path=temp_path,
+            filename=filename,
+            source_hash=hashlib.sha256(content).hexdigest(),
+        )
+    except URLSourceError:
+        if temp_path:
+            temp_path.unlink(missing_ok=True)
+        raise
+    except HTTPError as e:
+        raise URLSourceError(f"HTTP error downloading URL source: {e.code} {e.reason}") from e
+    except (URLError, TimeoutError) as e:
+        raise URLSourceError(f"Failed to download URL source: {e}") from e
+    except OSError as e:
+        if temp_path:
+            temp_path.unlink(missing_ok=True)
+        raise URLSourceError(f"Failed to store URL source: {e}") from e

--- a/src/uv_script_manager/utils.py
+++ b/src/uv_script_manager/utils.py
@@ -185,7 +185,7 @@ def validate_python_script(script_path: Path) -> bool:
     if not script_path.exists():
         return False
 
-    if not script_path.suffix == ".py":
+    if script_path.suffix.lower() != ".py":
         return False
 
     try:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -74,7 +74,8 @@ class TestMigration001AddSourceType:
 
         # Verify source_type was not changed
         script = scripts_table.get(doc_id=1)
-        assert script["source_type"] == "local"  # type: ignore[index]
+        assert isinstance(script, dict)
+        assert script.get("source_type") == "local"
 
         db.close()
 
@@ -154,7 +155,8 @@ class TestMigration002AddCopyParentDir:
 
         # Verify copy_parent_dir was not changed
         script = scripts_table.get(doc_id=1)
-        assert script["copy_parent_dir"] is True  # type: ignore[index]
+        assert isinstance(script, dict)
+        assert script.get("copy_parent_dir") is True
 
         db.close()
 
@@ -280,8 +282,9 @@ class TestMigrationRunner:
 
         # Verify migration was applied
         script = scripts_table.get(doc_id=1)
-        assert script["source_type"] == "git"  # type: ignore[index]
-        assert script["copy_parent_dir"] is False  # type: ignore[index]
+        assert isinstance(script, dict)
+        assert script.get("source_type") == "git"
+        assert script.get("copy_parent_dir") is False
 
         # Verify schema version was updated
         assert runner.get_schema_version() == CURRENT_SCHEMA_VERSION

--- a/tests/test_update_handler.py
+++ b/tests/test_update_handler.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import cast
 
 import pytest
 from rich.console import Console
@@ -138,7 +137,7 @@ def test_update_all_collects_errors_for_dry_and_apply_modes(tmp_path: Path, monk
     dry_error_found = False
     for row in dry_results:
         if len(row) == 3:
-            _script_name, status, local_changes = cast(tuple[str, str, str], row)
+            _script_name, status, local_changes = row
             if status == "Error: dry boom" and local_changes == "Unknown":
                 dry_error_found = True
                 break

--- a/tests/test_url_install_update.py
+++ b/tests/test_url_install_update.py
@@ -191,19 +191,23 @@ def test_cli_rejects_compiled_python_url(tmp_path: Path, monkeypatch) -> None:
 @pytest.mark.parametrize(
     ("options", "message"),
     [
-        (["--script", "tool.py"], "--script cannot be used with a direct .py URL"),
-        (["--copy-parent-dir"], "--copy-parent-dir cannot be used with a direct .py URL"),
-        (["--add-source-package", "tool"], "--add-source-package cannot be used with a direct .py URL"),
+        (("--script", "tool.py"), "--script cannot be used with a direct .py URL"),
+        (("--copy-parent-dir",), "--copy-parent-dir cannot be used with a direct .py URL"),
+        (("--add-source-package", "tool"), "--add-source-package cannot be used with a direct .py URL"),
     ],
 )
 def test_cli_rejects_url_incompatible_options_before_download(
-    tmp_path: Path, monkeypatch, options: list[str], message: str
+    tmp_path: Path, monkeypatch, options: tuple[str, ...], message: str
 ) -> None:
     _config(tmp_path)
     monkeypatch.setattr("uv_script_manager.cli.verify_uv_available", lambda: None)
+
+    def fail_download(*args) -> None:
+        raise AssertionError("invalid URL options must be rejected before download")
+
     monkeypatch.setattr(
         "uv_script_manager.commands.install.download_url_script",
-        lambda *args: pytest.fail("invalid URL options must be rejected before download"),
+        fail_download,
     )
 
     result = CliRunner().invoke(

--- a/tests/test_url_install_update.py
+++ b/tests/test_url_install_update.py
@@ -1,0 +1,215 @@
+"""Install and update tests for direct Python source URLs."""
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from tests.cli_helpers import _write_config
+from uv_script_manager.cli import cli
+from uv_script_manager.commands.install import InstallHandler, InstallRequest
+from uv_script_manager.commands.update import UpdateHandler
+from uv_script_manager.config import load_config
+from uv_script_manager.constants import SourceType
+from uv_script_manager.script_installer import ScriptInstallerError
+from uv_script_manager.state import ScriptInfo, StateManager
+from uv_script_manager.update_status import UPDATE_STATUS_UP_TO_DATE, UPDATE_STATUS_UPDATED, is_error_status
+from uv_script_manager.url_source import DownloadedURLScript, URLSourceError
+
+
+def _download(destination: Path, content: bytes, filename: str = "tool.py") -> DownloadedURLScript:
+    destination.mkdir(parents=True, exist_ok=True)
+    path = destination / ".download.py"
+    path.write_bytes(content)
+    return DownloadedURLScript(path, filename, hashlib.sha256(content).hexdigest())
+
+
+def _config(tmp_path: Path):
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, tmp_path / "repos", tmp_path / "bin", tmp_path / "state.json")
+    return load_config(config_path)
+
+
+def test_install_direct_url_persists_source_metadata(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    content = b"print('v1')\n"
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.download_url_script",
+        lambda url, destination: _download(destination, content),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.install_script",
+        lambda path, dependencies, install_config: (None, None),
+    )
+
+    request = InstallRequest(None, True, True, None, False, None, False, None, None, True)
+    result = InstallHandler(config, Console(record=True)).install("https://example.com/tool.py", (), request)
+
+    assert result[0][1] is True
+    script = StateManager(config.state_file).get_script("tool.py")
+    assert script is not None
+    assert script.source_type == SourceType.URL
+    assert script.source_url == "https://example.com/tool.py"
+    assert script.source_hash == hashlib.sha256(content).hexdigest()
+
+
+def test_update_direct_url_compares_hash_and_reinstalls(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    original = b"print('v1')\n"
+    changed = b"print('v2')\n"
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.download_url_script",
+        lambda url, destination: _download(destination, original),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.install_script",
+        lambda path, dependencies, install_config: (None, None),
+    )
+    request = InstallRequest(None, True, True, None, False, None, False, None, None, True)
+    InstallHandler(config, Console(record=True)).install("https://example.com/tool.py", (), request)
+
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.download_url_script",
+        lambda url, destination: _download(destination, original),
+    )
+    updater = UpdateHandler(config, Console(record=True))
+    assert updater.update("tool.py", False, None)[1] == UPDATE_STATUS_UP_TO_DATE
+
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.download_url_script",
+        lambda url, destination: _download(destination, changed),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.install_script",
+        lambda path, dependencies, install_config: (None, None),
+    )
+    assert updater.update("tool.py", False, None)[1] == UPDATE_STATUS_UPDATED
+
+    script = StateManager(config.state_file).get_script("tool.py")
+    assert script is not None
+    assert script.source_hash == hashlib.sha256(changed).hexdigest()
+    assert (script.repo_path / script.name).read_bytes() == changed
+
+
+def test_update_direct_url_restores_previous_file_on_install_failure(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    original = b"print('v1')\n"
+    changed = b"print('v2')\n"
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.download_url_script",
+        lambda url, destination: _download(destination, original),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.install_script",
+        lambda path, dependencies, install_config: (None, None),
+    )
+    request = InstallRequest(None, True, True, None, False, None, False, None, None, True)
+    InstallHandler(config, Console(record=True)).install("https://example.com/tool.py", (), request)
+
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.download_url_script",
+        lambda url, destination: _download(destination, changed),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.install_script",
+        lambda *args: (_ for _ in ()).throw(ScriptInstallerError("failed")),
+    )
+
+    result = UpdateHandler(config, Console(record=True)).update("tool.py", False, None)
+    script = StateManager(config.state_file).get_script("tool.py")
+
+    assert is_error_status(result[1])
+    assert script is not None
+    assert script.source_hash == hashlib.sha256(original).hexdigest()
+    assert (script.repo_path / script.name).read_bytes() == original
+
+
+def test_url_dry_run_rejects_redirected_filename_change(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    content = b"print('ok')\n"
+    script_dir = config.repo_dir / "url-test"
+    script_dir.mkdir(parents=True)
+    (script_dir / "tool.py").write_bytes(content)
+    StateManager(config.state_file).add_script(
+        ScriptInfo(
+            name="tool.py",
+            source_type=SourceType.URL,
+            source_url="https://example.com/tool.py",
+            source_hash=hashlib.sha256(content).hexdigest(),
+            installed_at=datetime.now(),
+            repo_path=script_dir,
+        )
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.update.download_url_script",
+        lambda url, destination: _download(destination, content, "renamed.py"),
+    )
+
+    with pytest.raises(URLSourceError, match="filename changed"):
+        UpdateHandler(config, Console(record=True)).update("tool.py", False, None, dry_run=True)
+
+
+def test_cli_installs_direct_url_without_script_option(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    content = b"print('ok')\n"
+    monkeypatch.setattr("uv_script_manager.cli.verify_uv_available", lambda: None)
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.download_url_script",
+        lambda url, destination: _download(destination, content),
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.install_script",
+        lambda path, dependencies, install_config: (None, None),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config", str(tmp_path / "config.toml"), "install", "https://example.com/tool.py", "--no-deps"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert StateManager(config.state_file).get_script("tool.py") is not None
+
+
+def test_cli_rejects_compiled_python_url(tmp_path: Path, monkeypatch) -> None:
+    _config(tmp_path)
+    monkeypatch.setattr("uv_script_manager.cli.verify_uv_available", lambda: None)
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config", str(tmp_path / "config.toml"), "install", "https://example.com/tool.pyc"],
+    )
+
+    assert result.exit_code == 1
+    assert "only installs Python source files ending in" in result.output
+    assert ".py" in result.output
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        (["--script", "tool.py"], "--script cannot be used with a direct .py URL"),
+        (["--copy-parent-dir"], "--copy-parent-dir cannot be used with a direct .py URL"),
+        (["--add-source-package", "tool"], "--add-source-package cannot be used with a direct .py URL"),
+    ],
+)
+def test_cli_rejects_url_incompatible_options_before_download(
+    tmp_path: Path, monkeypatch, options: list[str], message: str
+) -> None:
+    _config(tmp_path)
+    monkeypatch.setattr("uv_script_manager.cli.verify_uv_available", lambda: None)
+    monkeypatch.setattr(
+        "uv_script_manager.commands.install.download_url_script",
+        lambda *args: pytest.fail("invalid URL options must be rejected before download"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config", str(tmp_path / "config.toml"), "install", "https://example.com/tool.py", *options],
+    )
+
+    assert result.exit_code == 1
+    assert message in result.output

--- a/tests/test_url_source.py
+++ b/tests/test_url_source.py
@@ -1,0 +1,99 @@
+"""Tests for direct Python source URL handling."""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from uv_script_manager.url_source import (
+    UNSUPPORTED_URL_SOURCE,
+    URLSourceError,
+    download_url_script,
+    is_python_source_url,
+    is_unsupported_python_file_url,
+    managed_url_directory,
+)
+
+
+class FakeResponse:
+    """Minimal urllib response for download tests."""
+
+    def __init__(self, content: bytes, final_url: str) -> None:
+        self.content = content
+        self.final_url = final_url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self.final_url
+
+    def read(self, size: int) -> bytes:
+        return self.content[:size]
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://example.com/tool.py", True),
+        ("https://example.com/tool.PY?raw=1#fragment", True),
+        ("http://example.com/tool.py", True),
+        ("ftp://example.com/tool.py", False),
+        ("https://example.com/tool.pyc", False),
+        ("https://example.com/repo", False),
+    ],
+)
+def test_is_python_source_url(url: str, expected: bool) -> None:
+    assert is_python_source_url(url) is expected
+
+
+@pytest.mark.parametrize("suffix", [".pyc", ".pyo", ".pyz", ".so", ".pyd", ".dll", ".dylib", ".whl"])
+def test_unsupported_python_artifact_urls(suffix: str) -> None:
+    assert is_unsupported_python_file_url(f"https://example.com/tool{suffix}")
+
+
+def test_download_url_script_uses_final_filename_and_hash(tmp_path: Path, monkeypatch) -> None:
+    content = b"print('ok')\n"
+    monkeypatch.setattr(
+        "uv_script_manager.url_source.urlopen",
+        lambda *args, **kwargs: FakeResponse(content, "https://cdn.example.com/final.py"),
+    )
+
+    downloaded = download_url_script("https://example.com/original.py", tmp_path)
+
+    assert downloaded.filename == "final.py"
+    assert downloaded.source_hash == hashlib.sha256(content).hexdigest()
+    assert downloaded.path.read_bytes() == content
+
+
+def test_download_url_script_rejects_non_python_redirect(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "uv_script_manager.url_source.urlopen",
+        lambda *args, **kwargs: FakeResponse(b"<html></html>", "https://example.com/page.html"),
+    )
+
+    with pytest.raises(URLSourceError, match=UNSUPPORTED_URL_SOURCE):
+        download_url_script("https://example.com/tool.py", tmp_path)
+
+
+def test_download_url_script_rejects_oversized_response(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "uv_script_manager.url_source.URL_MAX_DOWNLOAD_SIZE",
+        4,
+    )
+    monkeypatch.setattr(
+        "uv_script_manager.url_source.urlopen",
+        lambda *args, **kwargs: FakeResponse(b"12345", "https://example.com/tool.py"),
+    )
+
+    with pytest.raises(URLSourceError, match="10 MiB"):
+        download_url_script("https://example.com/tool.py", tmp_path)
+
+
+def test_managed_url_directory_is_deterministic(tmp_path: Path) -> None:
+    url = "https://example.com/tool.py"
+    expected = hashlib.sha256(url.encode()).hexdigest()[:12]
+    assert managed_url_directory(tmp_path, url) == tmp_path / f"url-{expected}"


### PR DESCRIPTION
## Summary

This PR closes #7 

- Add install and update support for direct HTTP(S) Python source URLs, including raw `.py` files and raw Gist links.
- Persist URL-specific metadata in state, display, export/import, and status handling with a new `url` source type.
- Enforce URL-specific validation and safety checks, including `.py`-only sources, filename validation, and a 10 MiB download limit.
- Update CLI messaging and help text to describe direct URL workflows alongside Git and local sources.
